### PR TITLE
support relative path by dots

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ yarn global add @knowbee/checkgit
 ```cli
 $ checkgit <options> <path>
 $ checkgit -g e:
+$ checkgit -g ../
 ```
 
 ## Options:

--- a/index.js
+++ b/index.js
@@ -62,7 +62,9 @@ function checkGit(dir, done) {
 
 if (choice) {
   helper();
-  !choice.includes(":\\") ? (choice = choice.split(":")[0] + ":\\") : choice;
+  !choice.startsWith(".") && !choice.includes(":\\")
+    ? (choice = choice.split(":")[0] + ":\\")
+    : choice;
   process.argv.slice(2).forEach(function(cmd) {
     if (cmd === "-g" || cmd === "--git") {
       checkGit(choice, async function(err, data) {

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ if (!command) {
   console.log("  $ checkgit --help");
   console.log("  $ checkgit -h");
   console.log("  $ checkgit -g E:");
-  console.log("  $ checkgit -nogit E:");
+  console.log("  $ checkgit -g ../");
   process.exit();
 } else {
   helper();


### PR DESCRIPTION
#### What does this PR do?
Add support for checking for git repositories with relative paths by making use use dots, this helps mac os or linux users able to use this tool
#### Description of Task to be completed?
N/A
#### How should this be manually tested?
run `checkgit -g ../` in command line
#### Any background context you want to provide?
N/A
#### Screenshots (if appropriate)
N/A